### PR TITLE
calculate signature properly + fix package.json too be valid json - needed for npm

### DIFF
--- a/lib/mixpanel_api.coffee
+++ b/lib/mixpanel_api.coffee
@@ -64,9 +64,7 @@ class MixpanelAPI
     to_be_hashed = ''
     for key in keys
       continue if key is 'callback' or key is 'sig'
-      param = {}
-      param[key] = params[key]
-      to_be_hashed += querystring.stringify param
+      to_be_hashed += key + '=' + params[key]
     hash = crypto.createHash 'md5'
     hash.update to_be_hashed + @options.api_secret
     params.sig = hash.digest 'hex'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "http://github.com/campfirelabs/node-mixpanel-api.git",
+            "url": "http://github.com/campfirelabs/node-mixpanel-api.git"
         }
     ],
     "engines": {


### PR DESCRIPTION
Those commits fix:

1/ The signature is currently calculated improperly

This causes error such as error: 'Invalid API signature'

2/ Currently npm fails to install the module because  package.json is invalid:

npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: ../mixpanel-api/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse
