### PR TITLE
package.json not json-valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "http://github.com/campfirelabs/node-mixpanel-api.git",
+            "url": "http://github.com/campfirelabs/node-mixpanel-api.git"
         }
     ],
     "engines": {


### PR DESCRIPTION
There is an extra-comma at the end of line 13, which makes package.json not valid... which prevents npm intall.
