### PR TITLE
Support for signed url's only, enforce coffeescript 1.6.3

### DIFF
--- a/lib/mixpanel_api.coffee
+++ b/lib/mixpanel_api.coffee
@@ -13,6 +13,28 @@ class MixpanelAPI
     @options[key] = val for key, val of options
     if not @options.api_key and @options.api_secret
       throw new Error 'MixpanelAPI needs token and secret parameters'
+
+  # duration is optional
+  signedUrl: (endpoint, params, valid_for, cb) ->
+    cb or= @options.log_fn
+    try
+      if typeof params isnt 'object' or typeof endpoint isnt 'string'
+        throw new Error 'request(endpoint, params, [valid_for], [cb]) expects an object params'
+
+      if arguments.length is 3 and typeof arguments[2] is 'function'
+        cb = valid_for
+        valid_for = null
+
+      valid_for or= @options.default_valid_for
+      cb or= @options.log_fn
+
+      params.api_key = @options.api_key
+      params.expire = Math.floor(Date.now()/1000) + valid_for
+
+      params_qs = querystring.stringify @_sign_params params
+      cb 'http://mixpanel.com/api/2.0/' + endpoint + '?' + params_qs
+
+    catch e then cb e
     
   # duration is optional
   request: (endpoint, params, valid_for, cb) ->

--- a/lib/mixpanel_api.coffee
+++ b/lib/mixpanel_api.coffee
@@ -24,7 +24,7 @@ class MixpanelAPI
       if arguments.length is 3 and typeof arguments[2] is 'function'
         cb = valid_for
         valid_for = null
-
+        
       valid_for or= @options.default_valid_for
       cb or= @options.log_fn
 
@@ -32,7 +32,7 @@ class MixpanelAPI
       params.expire = Math.floor(Date.now()/1000) + valid_for
 
       params_qs = querystring.stringify @_sign_params params
-      cb 'http://mixpanel.com/api/2.0/' + endpoint + '?' + params_qs
+      cb null, 'http://mixpanel.com/api/2.0/' + endpoint + '?' + params_qs
 
     catch e then cb e
     
@@ -88,7 +88,7 @@ class MixpanelAPI
       continue if key is 'callback' or key is 'sig'
       param = {}
       param[key] = params[key]
-      to_be_hashed += querystring.stringify param
+      to_be_hashed += querystring.unescape querystring.stringify param
     hash = crypto.createHash 'md5'
     hash.update to_be_hashed + @options.api_secret
     params.sig = hash.digest 'hex'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "email": "jonas.huckestein@gmail.com",
         "url": "http://thezukunft.com"
     },
-    "repositories": [
+    "repository": [
         {
             "type": "git",
             "url": "http://github.com/campfirelabs/node-mixpanel-api.git"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "http://github.com/campfirelabs/node-mixpanel-api.git",
+            "url": "http://github.com/campfirelabs/node-mixpanel-api.git"
         }
     ],
     "engines": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     },
     "main": "./index.js",
     "dependencies": {
-        "coffee-script": ">= 1.0.0"
+        "coffee-script": "1.6.3"
     }
 }


### PR DESCRIPTION
Added support for only doing signed url's only. Also forced to coffeescript 1.6.3 as 1.7 had breaking changes I'm told.
