### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "http://github.com/campfirelabs/node-mixpanel-api.git",
+            "url": "http://github.com/campfirelabs/node-mixpanel-api.git"
         }
     ],
     "engines": {


### PR DESCRIPTION
This issue prevents the JSON file from being parsed, thus not allowing the command `npm install` to run
